### PR TITLE
Improve Game List view with status and progress

### DIFF
--- a/FirePorker/Controllers/GameController.cs
+++ b/FirePorker/Controllers/GameController.cs
@@ -135,6 +135,26 @@ public class GameController : Controller
         return View(games);
     }
 
+    // GET: Game/ListData (JSON for AJAX refresh)
+    [HttpGet]
+    public IActionResult ListData()
+    {
+        var games = GameManager.GetPokerGames()
+            .OrderByDescending(g => g.Status == "Voting")
+            .ThenByDescending(g => g.Players.Count)
+            .Select(g => new
+            {
+                id = g.Id.ToString(),
+                name = g.Name,
+                description = g.Description,
+                playerCount = g.Players.Count,
+                status = g.Status,
+                progress = g.Progress,
+                expiresIn = g.ExpiresIn
+            });
+        return Json(games);
+    }
+
     // POST: Game/Create
     [HttpPost]
     public IActionResult Create(string? HostName, string? Name, string? Description)

--- a/FirePorker/Controllers/GameController.cs
+++ b/FirePorker/Controllers/GameController.cs
@@ -144,7 +144,6 @@ public class GameController : Controller
             .ThenByDescending(g => g.Players.Count)
             .Select(g => new
             {
-                id = g.Id.ToString(),
                 name = g.Name,
                 playerCount = g.Players.Count,
                 status = g.Status,

--- a/FirePorker/Controllers/GameController.cs
+++ b/FirePorker/Controllers/GameController.cs
@@ -146,7 +146,6 @@ public class GameController : Controller
             {
                 id = g.Id.ToString(),
                 name = g.Name,
-                description = g.Description,
                 playerCount = g.Players.Count,
                 status = g.Status,
                 progress = g.Progress,

--- a/FirePorker/Controllers/GameController.cs
+++ b/FirePorker/Controllers/GameController.cs
@@ -144,6 +144,7 @@ public class GameController : Controller
             .ThenByDescending(g => g.Players.Count)
             .Select(g => new
             {
+                key = g.TrackingKey,
                 name = g.Name,
                 playerCount = g.Players.Count,
                 status = g.Status,

--- a/FirePorker/Controllers/GameController.cs
+++ b/FirePorker/Controllers/GameController.cs
@@ -129,15 +129,15 @@ public class GameController : Controller
 #endif
     }
 
-    public IActionResult List()
+    public IActionResult Activity()
     {
         var games = GameManager.GetPokerGames();
         return View(games);
     }
 
-    // GET: Game/ListData (JSON for AJAX refresh)
+    // GET: Game/ActivityData (JSON for AJAX refresh)
     [HttpGet]
-    public IActionResult ListData()
+    public IActionResult ActivityData()
     {
         var games = GameManager.GetPokerGames()
             .OrderByDescending(g => g.Status == "Voting")

--- a/FirePorker/Models/PokerGame.cs
+++ b/FirePorker/Models/PokerGame.cs
@@ -60,6 +60,9 @@ public class PokerGame
             return $"in {(int)remaining.TotalDays}d";
         }
     }
+    
+    // Stable tracking key for activity view (not reversible to real ID)
+    public string TrackingKey => Id.GetHashCode().ToString("x8");
 
     // TODO: Configurable number set?
     

--- a/FirePorker/Models/PokerGame.cs
+++ b/FirePorker/Models/PokerGame.cs
@@ -19,6 +19,48 @@ public class PokerGame
     public IList<Story> Stories { get; set; }
     public DateTime RoundStarted { get; set; }
 
+    // Computed properties for list view
+    public Story? CurrentStory => Stories.FirstOrDefault(s => s.Estimate == null);
+    
+    public string Status
+    {
+        get
+        {
+            if (CurrentStory == null)
+                return "Idle";
+            
+            var votedCount = Players.Count(p => p.CurrentVote != null);
+            return votedCount > 0 ? "Voting" : "Waiting";
+        }
+    }
+    
+    public int VotedCount => Players.Count(p => p.CurrentVote != null);
+    
+    public string Progress
+    {
+        get
+        {
+            if (CurrentStory == null)
+                return "—";
+            return $"{VotedCount}/{Players.Count}";
+        }
+    }
+    
+    public string ExpiresIn
+    {
+        get
+        {
+            var remaining = ExpirationDate - DateTime.UtcNow;
+            if (remaining.TotalMinutes < 1)
+                return "soon";
+            if (remaining.TotalHours < 1)
+                return $"in {(int)remaining.TotalMinutes}m";
+            if (remaining.TotalDays < 1)
+                return $"in {(int)remaining.TotalHours}h";
+            return $"in {(int)remaining.TotalDays}d";
+        }
+    }
+
     // TODO: Configurable number set?
     
     public PokerGame(string name, string hostName, string description = "", string id = "")

--- a/FirePorker/Views/Game/Activity.cshtml
+++ b/FirePorker/Views/Game/Activity.cshtml
@@ -46,7 +46,7 @@
             <tbody id="game-tbody">
             @foreach (var game in Model.OrderByDescending(g => g.Status == "Voting").ThenByDescending(g => g.Players.Count))
             {
-                <tr data-game-id="@game.Id" data-status="@game.Status" data-progress="@game.Progress" data-players="@game.Players.Count">
+                <tr data-game-name="@game.Name" data-status="@game.Status" data-progress="@game.Progress" data-players="@game.Players.Count">
                     <td><strong>@game.Name</strong></td>
                     <td>@game.Players.Count</td>
                     <td>
@@ -92,8 +92,8 @@
 
     function initializeData() {
         $('#game-tbody tr').each(function() {
-            var id = $(this).data('game-id');
-            previousData[id] = {
+            var name = $(this).data('game-name');
+            previousData[name] = {
                 status: $(this).data('status'),
                 progress: $(this).data('progress'),
                 players: $(this).data('players')
@@ -121,10 +121,10 @@
                 return;
             }
 
-            var newIds = {};
+            var newNames = {};
             games.forEach(function(game) {
-                newIds[game.id] = true;
-                var row = $('tr[data-game-id="' + game.id + '"]');
+                newNames[game.name] = true;
+                var row = $('tr[data-game-name="' + game.name.replace(/"/g, '\\"') + '"]');
                 
                 if (row.length === 0) {
                     // New game - will pulse after reload
@@ -133,7 +133,7 @@
                 }
 
                 // Check for changes
-                var prev = previousData[game.id] || {};
+                var prev = previousData[game.name] || {};
                 var changed = prev.status !== game.status || 
                               prev.progress !== game.progress || 
                               prev.players !== game.playerCount;
@@ -146,7 +146,7 @@
                 }
 
                 // Update tracking
-                previousData[game.id] = {
+                previousData[game.name] = {
                     status: game.status,
                     progress: game.progress,
                     players: game.playerCount
@@ -154,12 +154,12 @@
             });
 
             // Check for removed games
-            for (var id in previousData) {
-                if (!newIds[id]) {
-                    $('tr[data-game-id="' + id + '"]').fadeOut(300, function() {
+            for (var name in previousData) {
+                if (!newNames[name]) {
+                    $('tr[data-game-name="' + name.replace(/"/g, '\\"') + '"]').fadeOut(300, function() {
                         $(this).remove();
                     });
-                    delete previousData[id];
+                    delete previousData[name];
                 }
             }
 

--- a/FirePorker/Views/Game/Activity.cshtml
+++ b/FirePorker/Views/Game/Activity.cshtml
@@ -46,7 +46,7 @@
             <tbody id="game-tbody">
             @foreach (var game in Model.OrderByDescending(g => g.Status == "Voting").ThenByDescending(g => g.Players.Count))
             {
-                <tr data-game-name="@game.Name" data-status="@game.Status" data-progress="@game.Progress" data-players="@game.Players.Count">
+                <tr data-key="@game.TrackingKey" data-status="@game.Status" data-progress="@game.Progress" data-players="@game.Players.Count">
                     <td><strong>@game.Name</strong></td>
                     <td>@game.Players.Count</td>
                     <td>
@@ -92,8 +92,8 @@
 
     function initializeData() {
         $('#game-tbody tr').each(function() {
-            var name = $(this).data('game-name');
-            previousData[name] = {
+            var key = $(this).data('key');
+            previousData[key] = {
                 status: $(this).data('status'),
                 progress: $(this).data('progress'),
                 players: $(this).data('players')
@@ -121,10 +121,10 @@
                 return;
             }
 
-            var newNames = {};
+            var newKeys = {};
             games.forEach(function(game) {
-                newNames[game.name] = true;
-                var row = $('tr[data-game-name="' + game.name.replace(/"/g, '\\"') + '"]');
+                newKeys[game.key] = true;
+                var row = $('tr[data-key="' + game.key + '"]');
                 
                 if (row.length === 0) {
                     // New game - will pulse after reload
@@ -133,7 +133,7 @@
                 }
 
                 // Check for changes
-                var prev = previousData[game.name] || {};
+                var prev = previousData[game.key] || {};
                 var changed = prev.status !== game.status || 
                               prev.progress !== game.progress || 
                               prev.players !== game.playerCount;
@@ -146,7 +146,7 @@
                 }
 
                 // Update tracking
-                previousData[game.name] = {
+                previousData[game.key] = {
                     status: game.status,
                     progress: game.progress,
                     players: game.playerCount
@@ -154,12 +154,12 @@
             });
 
             // Check for removed games
-            for (var name in previousData) {
-                if (!newNames[name]) {
-                    $('tr[data-game-name="' + name.replace(/"/g, '\\"') + '"]').fadeOut(300, function() {
+            for (var key in previousData) {
+                if (!newKeys[key]) {
+                    $('tr[data-key="' + key + '"]').fadeOut(300, function() {
                         $(this).remove();
                     });
-                    delete previousData[name];
+                    delete previousData[key];
                 }
             }
 

--- a/FirePorker/Views/Game/Activity.cshtml
+++ b/FirePorker/Views/Game/Activity.cshtml
@@ -102,7 +102,7 @@
     }
 
     function refreshList() {
-        $.getJSON('@Url.Action("ListData", "Game")', function(games) {
+        $.getJSON('@Url.Action("ActivityData", "Game")', function(games) {
             if (games.length === 0) {
                 // Show empty state
                 $('#game-list-container').html(

--- a/FirePorker/Views/Game/List.cshtml
+++ b/FirePorker/Views/Game/List.cshtml
@@ -4,72 +4,209 @@
     ViewBag.Title = "Activity";
 }
 
+<style>
+    @@keyframes pulse {
+        0% { background-color: rgba(92, 184, 92, 0.3); }
+        100% { background-color: transparent; }
+    }
+    .pulse {
+        animation: pulse 1.5s ease-out;
+    }
+    .status-label {
+        min-width: 60px;
+        display: inline-block;
+        text-align: center;
+    }
+</style>
+
 <h2>Activity</h2>
 <p class="text-muted">Active planning poker sessions</p>
 
-@if (!Model.Any())
-{
-    <div class="alert alert-info">
-        <strong>No active games right now.</strong>
-        <br />
-        <a href="@Url.Action("Create", "Game")">Create a new game</a> to get started.
-    </div>
-}
-else
-{
-    <table class="table table-striped">
-        <thead>
-            <tr>
-                <th>Game</th>
-                <th>Players</th>
-                <th>Status</th>
-                <th>Progress</th>
-                <th>Expires</th>
-            </tr>
-        </thead>
-        <tbody>
-        @foreach (var game in Model.OrderByDescending(g => g.Status == "Voting").ThenByDescending(g => g.Players.Count))
-        {
-            <tr>
-                <td>
-                    <strong>@game.Name</strong>
-                    @if (!string.IsNullOrEmpty(game.Description))
-                    {
-                        <br /><small class="text-muted">@game.Description</small>
-                    }
-                </td>
-                <td>@game.Players.Count</td>
-                <td>
-                    @if (game.Status == "Voting")
-                    {
-                        <span class="label label-success">Voting</span>
-                    }
-                    else if (game.Status == "Waiting")
-                    {
-                        <span class="label label-warning">Waiting</span>
-                    }
-                    else
-                    {
-                        <span class="label label-default">Idle</span>
-                    }
-                </td>
-                <td>
-                    @if (game.Status != "Idle")
-                    {
-                        <span>@game.Progress voted</span>
-                    }
-                    else
-                    {
-                        <span class="text-muted">—</span>
-                    }
-                </td>
-                <td><span class="text-muted">@game.ExpiresIn</span></td>
-            </tr>
+<div id="game-list-container">
+    @if (!Model.Any())
+    {
+        <div class="alert alert-info" id="empty-state">
+            <strong>No active games right now.</strong>
+            <br />
+            <a href="@Url.Action("Create", "Game")">Create a new game</a> to get started.
+        </div>
+    }
+    else
+    {
+        <table class="table table-striped" id="game-table">
+            <thead>
+                <tr>
+                    <th>Game</th>
+                    <th>Players</th>
+                    <th>Status</th>
+                    <th>Progress</th>
+                    <th>Expires</th>
+                </tr>
+            </thead>
+            <tbody id="game-tbody">
+            @foreach (var game in Model.OrderByDescending(g => g.Status == "Voting").ThenByDescending(g => g.Players.Count))
+            {
+                <tr data-game-id="@game.Id" data-status="@game.Status" data-progress="@game.Progress" data-players="@game.Players.Count">
+                    <td>
+                        <strong>@game.Name</strong>
+                        @if (!string.IsNullOrEmpty(game.Description))
+                        {
+                            <br /><small class="text-muted">@game.Description</small>
+                        }
+                    </td>
+                    <td>@game.Players.Count</td>
+                    <td>
+                        @if (game.Status == "Voting")
+                        {
+                            <span class="label label-success status-label">Voting</span>
+                        }
+                        else if (game.Status == "Waiting")
+                        {
+                            <span class="label label-warning status-label">Waiting</span>
+                        }
+                        else
+                        {
+                            <span class="label label-default status-label">Idle</span>
+                        }
+                    </td>
+                    <td>
+                        @if (game.Status != "Idle")
+                        {
+                            <span>@game.Progress voted</span>
+                        }
+                        else
+                        {
+                            <span class="text-muted">—</span>
+                        }
+                    </td>
+                    <td><span class="text-muted">@game.ExpiresIn</span></td>
+                </tr>
+            }
+            </tbody>
+        </table>
+        
+        <p class="text-muted">
+            <small><span id="game-count">@Model.Count()</span> active game@(Model.Count() != 1 ? "s" : "")</small>
+        </p>
+    }
+</div>
+
+@section Scripts {
+<script>
+    var previousData = {};
+    var refreshInterval = 5000; // 5 seconds
+
+    function initializeData() {
+        $('#game-tbody tr').each(function() {
+            var id = $(this).data('game-id');
+            previousData[id] = {
+                status: $(this).data('status'),
+                progress: $(this).data('progress'),
+                players: $(this).data('players')
+            };
+        });
+    }
+
+    function refreshList() {
+        $.getJSON('@Url.Action("ListData", "Game")', function(games) {
+            if (games.length === 0) {
+                // Show empty state
+                $('#game-list-container').html(
+                    '<div class="alert alert-info" id="empty-state">' +
+                    '<strong>No active games right now.</strong><br />' +
+                    '<a href="@Url.Action("Create", "Game")">Create a new game</a> to get started.' +
+                    '</div>'
+                );
+                previousData = {};
+                return;
+            }
+
+            // Build new table if it doesn't exist
+            if ($('#game-table').length === 0) {
+                location.reload(); // Simple reload if structure changed
+                return;
+            }
+
+            var newIds = {};
+            games.forEach(function(game) {
+                newIds[game.id] = true;
+                var row = $('tr[data-game-id="' + game.id + '"]');
+                
+                if (row.length === 0) {
+                    // New game - will pulse after reload
+                    location.reload();
+                    return;
+                }
+
+                // Check for changes
+                var prev = previousData[game.id] || {};
+                var changed = prev.status !== game.status || 
+                              prev.progress !== game.progress || 
+                              prev.players !== game.playerCount;
+
+                if (changed) {
+                    // Update the row
+                    updateRow(row, game);
+                    row.addClass('pulse');
+                    setTimeout(function() { row.removeClass('pulse'); }, 1500);
+                }
+
+                // Update tracking
+                previousData[game.id] = {
+                    status: game.status,
+                    progress: game.progress,
+                    players: game.playerCount
+                };
+            });
+
+            // Check for removed games
+            for (var id in previousData) {
+                if (!newIds[id]) {
+                    $('tr[data-game-id="' + id + '"]').fadeOut(300, function() {
+                        $(this).remove();
+                    });
+                    delete previousData[id];
+                }
+            }
+
+            // Update count
+            $('#game-count').text(games.length);
+        });
+    }
+
+    function updateRow(row, game) {
+        row.data('status', game.status);
+        row.data('progress', game.progress);
+        row.data('players', game.playerCount);
+
+        // Update player count
+        row.find('td:eq(1)').text(game.playerCount);
+
+        // Update status
+        var statusHtml;
+        if (game.status === 'Voting') {
+            statusHtml = '<span class="label label-success status-label">Voting</span>';
+        } else if (game.status === 'Waiting') {
+            statusHtml = '<span class="label label-warning status-label">Waiting</span>';
+        } else {
+            statusHtml = '<span class="label label-default status-label">Idle</span>';
         }
-        </tbody>
-    </table>
-    
-    <p class="text-muted">
-        <small>@Model.Count() active game@(Model.Count() != 1 ? "s" : "")</small>
-    </p>
+        row.find('td:eq(2)').html(statusHtml);
+
+        // Update progress
+        if (game.status !== 'Idle') {
+            row.find('td:eq(3)').html('<span>' + game.progress + ' voted</span>');
+        } else {
+            row.find('td:eq(3)').html('<span class="text-muted">—</span>');
+        }
+
+        // Update expires
+        row.find('td:eq(4)').html('<span class="text-muted">' + game.expiresIn + '</span>');
+    }
+
+    $(function() {
+        initializeData();
+        setInterval(refreshList, refreshInterval);
+    });
+</script>
 }

--- a/FirePorker/Views/Game/List.cshtml
+++ b/FirePorker/Views/Game/List.cshtml
@@ -1,27 +1,75 @@
-﻿@model IEnumerable<FirePorker.Models.PokerGame>
+@model IEnumerable<FirePorker.Models.PokerGame>
 
 @{
-    ViewBag.Title = "Game List";
+    ViewBag.Title = "Activity";
 }
 
-<h2>Games</h2>
+<h2>Activity</h2>
+<p class="text-muted">Active planning poker sessions</p>
 
-<table class="table table-striped table-hover">
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Players</th>
-            <th>Expires</th>
-        </tr>
-    </thead>
-    <tbody>
-    @foreach (var game in Model)
-    {
-        <tr>
-            <td>@game.Name</td>
-            <td>@game.Players.Count</td>
-            <td>@game.ExpirationDate.ToString("R")</td>
-        </tr>
-    }
-    </tbody>
-</table>
+@if (!Model.Any())
+{
+    <div class="alert alert-info">
+        <strong>No active games right now.</strong>
+        <br />
+        <a href="@Url.Action("Create", "Game")">Create a new game</a> to get started.
+    </div>
+}
+else
+{
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Game</th>
+                <th>Players</th>
+                <th>Status</th>
+                <th>Progress</th>
+                <th>Expires</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var game in Model.OrderByDescending(g => g.Status == "Voting").ThenByDescending(g => g.Players.Count))
+        {
+            <tr>
+                <td>
+                    <strong>@game.Name</strong>
+                    @if (!string.IsNullOrEmpty(game.Description))
+                    {
+                        <br /><small class="text-muted">@game.Description</small>
+                    }
+                </td>
+                <td>@game.Players.Count</td>
+                <td>
+                    @if (game.Status == "Voting")
+                    {
+                        <span class="label label-success">Voting</span>
+                    }
+                    else if (game.Status == "Waiting")
+                    {
+                        <span class="label label-warning">Waiting</span>
+                    }
+                    else
+                    {
+                        <span class="label label-default">Idle</span>
+                    }
+                </td>
+                <td>
+                    @if (game.Status != "Idle")
+                    {
+                        <span>@game.Progress voted</span>
+                    }
+                    else
+                    {
+                        <span class="text-muted">—</span>
+                    }
+                </td>
+                <td><span class="text-muted">@game.ExpiresIn</span></td>
+            </tr>
+        }
+        </tbody>
+    </table>
+    
+    <p class="text-muted">
+        <small>@Model.Count() active game@(Model.Count() != 1 ? "s" : "")</small>
+    </p>
+}

--- a/FirePorker/Views/Game/List.cshtml
+++ b/FirePorker/Views/Game/List.cshtml
@@ -47,13 +47,7 @@
             @foreach (var game in Model.OrderByDescending(g => g.Status == "Voting").ThenByDescending(g => g.Players.Count))
             {
                 <tr data-game-id="@game.Id" data-status="@game.Status" data-progress="@game.Progress" data-players="@game.Players.Count">
-                    <td>
-                        <strong>@game.Name</strong>
-                        @if (!string.IsNullOrEmpty(game.Description))
-                        {
-                            <br /><small class="text-muted">@game.Description</small>
-                        }
-                    </td>
+                    <td><strong>@game.Name</strong></td>
                     <td>@game.Players.Count</td>
                     <td>
                         @if (game.Status == "Voting")

--- a/FirePorker/Views/Shared/_Layout.cshtml
+++ b/FirePorker/Views/Shared/_Layout.cshtml
@@ -27,7 +27,7 @@
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
                     <li><a asp-controller="Home" asp-action="Index">Home</a></li>
-                    <li><a asp-controller="Game" asp-action="List">Activity</a></li>
+                    <li><a asp-controller="Game" asp-action="Activity">Activity</a></li>
                     <li><a asp-controller="Home" asp-action="About">About</a></li>
                 </ul>
             </div>

--- a/FirePorker/Views/Shared/_Layout.cshtml
+++ b/FirePorker/Views/Shared/_Layout.cshtml
@@ -27,6 +27,7 @@
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
                     <li><a asp-controller="Home" asp-action="Index">Home</a></li>
+                    <li><a asp-controller="Game" asp-action="List">Activity</a></li>
                     <li><a asp-controller="Home" asp-action="About">About</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
## Summary
Enhances the Game List page to show more useful information about active games.

## Changes

**New columns:**
- **Status**: Voting (green), Waiting (yellow), Idle (gray)
- **Progress**: X/Y voted when a story is active
- **Expires**: Relative time (in 23h, in 2d) instead of full timestamp

**Model additions:**
- `CurrentStory` - computed property for active story
- `Status` - computed based on story and vote state
- `VotedCount` - players who have voted
- `Progress` - formatted vote progress
- `ExpiresIn` - relative expiration time

**UI improvements:**
- Sort by active games first, then by player count
- Empty state with CTA to create a game
- Show game description if present
- Footer count of active games
- Added 'Activity' link to navbar

## Screenshots
N/A - no local testing environment

## Privacy
No player names or identifiable info exposed. Anonymous activity view only.