### PR TITLE
Fix issue #13: Correct voter counts when host cannot vote

### DIFF
--- a/FirePorker/Controllers/GameController.cs
+++ b/FirePorker/Controllers/GameController.cs
@@ -144,12 +144,12 @@ public class GameController : Controller
     {
         var games = GameManager.GetPokerGames()
             .OrderByDescending(g => g.Status == "Voting")
-            .ThenByDescending(g => g.Players.Count)
+            .ThenByDescending(g => g.ExpectedVoterCount)
             .Select(g => new
             {
                 key = g.TrackingKey,
                 name = g.Name,
-                playerCount = g.Players.Count,
+                playerCount = g.ExpectedVoterCount,
                 status = g.Status,
                 progress = g.Progress,
                 expiresIn = g.ExpiresIn

--- a/FirePorker/Models/PokerGame.cs
+++ b/FirePorker/Models/PokerGame.cs
@@ -33,12 +33,20 @@ public class PokerGame
             if (CurrentStory == null)
                 return "Idle";
             
-            var votedCount = Players.Count(p => p.CurrentVote != null);
+            var votedCount = HostCanVote 
+                ? Players.Count(p => p.CurrentVote != null)
+                : Players.Count(p => p.CurrentVote != null && p.Id != Host.Id);
             return votedCount > 0 ? "Voting" : "Waiting";
         }
     }
     
-    public int VotedCount => Players.Count(p => p.CurrentVote != null);
+    public int VotedCount => HostCanVote 
+        ? Players.Count(p => p.CurrentVote != null)
+        : Players.Count(p => p.CurrentVote != null && p.Id != Host.Id);
+    
+    public int ExpectedVoterCount => HostCanVote 
+        ? Players.Count
+        : Players.Count - 1; // Exclude host from total when they can't vote
     
     public string Progress
     {
@@ -46,7 +54,7 @@ public class PokerGame
         {
             if (CurrentStory == null)
                 return "—";
-            return $"{VotedCount}/{Players.Count}";
+            return $"{VotedCount}/{ExpectedVoterCount}";
         }
     }
     

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ A real-time planning poker app for agile teams. Built with ASP.NET Core 8 and Si
 ## Features
 
 - **Real-time voting** — See votes appear instantly via SignalR
-- **Multiple games** — Host multiple concurrent planning sessions
-- **Story management** — Add stories, track estimates
+- **Multiple games** — Host multiple concurrent planning sessions  
+- **Story management** — Add stories, track estimates, optionally link to Jira
+- **Host voting control** — Choose whether the host participates in voting
 - **Host controls** — Clear votes, accept estimates, remove players
+- **Activity dashboard** — View all active games and their voting status
 - **No accounts needed** — Cookie-based sessions, jump right in
 
 ## Quick Start


### PR DESCRIPTION
Fixes #13

### Changes

**Activity page vote counting:**
- When `HostCanVote` is false, the activity page now excludes the host from:
  - Vote progress display (shows X/(total-1) instead of X/total)
  - Expected voter count
  - Player count sorting

**Implementation:**
- Added `ExpectedVoterCount` property to `PokerGame` that adjusts based on `HostCanVote`
- Updated `VotedCount` to exclude host votes when they can't vote
- Updated `ActivityData` endpoint to use expected voters for display
- Updated README to reflect current features (host voting control, activity dashboard, Jira integration)

### Example
Before: Game with 3 players, host can't vote → shows "1/3 voted" (incorrect)
After: Same game → shows "1/2 voted" (correct)

### Testing
- Create game with host voting disabled
- Add 2 other players
- Verify activity page shows correct vote counts